### PR TITLE
Needs GHC >= 7.6 due to Prelude.catch conflict

### DIFF
--- a/web-routes/web-routes.cabal
+++ b/web-routes/web-routes.cabal
@@ -24,7 +24,7 @@ test-suite Test
                      web-routes
 
 Library
-        Build-Depends:    base          >= 4    && < 5,
+        Build-Depends:    base          >= 4.6  && < 5,
                           blaze-builder >= 0.2  && < 0.5,
                           parsec        >= 2    && < 4,
                           bytestring    >= 0.9  && < 0.11,
@@ -33,8 +33,6 @@ Library
                           text          >= 0.11 && < 1.3,
                           utf8-string   >= 0.3  && < 1.1,
                           exceptions    >= 0.6.1 && < 0.9
-        if impl(ghc >= 7.2)
-          Build-Depends:  ghc-prim, split
         Exposed-Modules:  Web.Routes
                           Web.Routes.Base
                           Web.Routes.PathInfo


### PR DESCRIPTION
This only applies to the latest version which I revised: http://hackage.haskell.org/package/web-routes-0.27.9/revisions/

A new release is only needed if you wish to add backwards compatibility.

Build matrix: http://matrix.hackage.haskell.org/package/web-routes