### PR TITLE
PathInfo: Write generalized instance for [a]

### DIFF
--- a/Web/Routes/PathInfo.hs
+++ b/Web/Routes/PathInfo.hs
@@ -308,17 +308,9 @@ instance PathInfo Text where
   toPathSegments = (:[])
   fromPathSegments = anySegment
 
-instance PathInfo [Text] where
-  toPathSegments = id
-  fromPathSegments = many anySegment
-
 instance PathInfo String where
   toPathSegments = (:[]) . pack
   fromPathSegments = unpack <$> anySegment
-
-instance PathInfo [String] where
-  toPathSegments = id . map pack
-  fromPathSegments = many (unpack <$> anySegment)
 
 instance PathInfo Int where
   toPathSegments i = [pack $ show i]
@@ -340,3 +332,7 @@ instance PathInfo Integer where
                  | Text.null r -> Just n
                  | otherwise -> Nothing
 
+
+instance PathInfo a => PathInfo [a] where
+  toPathSegments = concat . fmap toPathSegments
+  fromPathSegments = many fromPathSegments


### PR DESCRIPTION
This patch replaces the two specialized instances of `PathInfo` for `[String]` and `[Text]` with an instance for `[a]` for all types `a`. The generalized instance has identical behaviour for `[String]` and `[Text]` to the removed instances.

For example, in combination with the `web-routes-th` package, the following data type is possible:

``` haskell
data Route = Search
           | ViewSubTree [Integer]
           | NewLeaf [Integer] String
```

This would match for the following URLs:

```
/search
/view-sub-tree/<Integer>/<Integer>/..etc..
/new-leaf/<Integer>/<Integer>/..etc../<String>
```
